### PR TITLE
Fix alphatest & Feat culling

### DIFF
--- a/packages/core/src/streams/sc2.ts
+++ b/packages/core/src/streams/sc2.ts
@@ -15,6 +15,9 @@ type DataNode = {
   qualityGroup?: string;
   fxName?: string;
   textures?: Textures;
+  customCullMode?: number;
+  enabledPresets?: EnabledPresets;
+  properties?: Properties;
 } & (
   | ({
       configCount: number;
@@ -24,7 +27,7 @@ type DataNode = {
     }
 );
 
-interface ConfigArchive {
+export interface ConfigArchive {
   configName: string;
   fxName: string;
   properties: Properties;

--- a/packages/scripts/src/core/blitz/extractModel/index.ts
+++ b/packages/scripts/src/core/blitz/extractModel/index.ts
@@ -75,9 +75,26 @@ export async function extractModel(vfs: AbstractVFS, path: string) {
           .setImage(baseColor),
       );
 
+      const defaultConfigArchive =
+        typeof node.configCount === "number"
+          ? (times(
+              node.configCount,
+              (index) => node[`configArchive_${index}`],
+            ).find((archive) => archive.configName === "Default") ??
+            node.configArchive_0)
+          : undefined;
+      const customCullMode =
+        node.customCullMode ?? defaultConfigArchive?.customCullMode;
+
+      if (customCullMode === 0) {
+        material.setDoubleSided(true);
+      } else if (customCullMode !== undefined) {
+        material.setDoubleSided(false);
+      }
+
       if (
         node.enabledPresets?.AlphaTest &&
-        node.properties.alphatestThreshold
+        node.properties?.alphatestThreshold
       ) {
         const view = new DataView(node.properties.alphatestThreshold);
         const alphaCutoff =
@@ -98,7 +115,8 @@ export async function extractModel(vfs: AbstractVFS, path: string) {
 
           if (
             archive.configName !== "Default" ||
-            !archive.enabledPresets?.AlphaTest
+            !archive.enabledPresets?.AlphaTest ||
+            !archive.properties?.alphatestThreshold
           ) {
             continue;
           }

--- a/packages/scripts/src/core/blitz/extractModel/index.ts
+++ b/packages/scripts/src/core/blitz/extractModel/index.ts
@@ -1,5 +1,6 @@
 import {
   bufferToBigInt,
+  ConfigArchive,
   Hierarchy,
   Sc2ReadStream,
   ScgReadStream,
@@ -75,14 +76,20 @@ export async function extractModel(vfs: AbstractVFS, path: string) {
           .setImage(baseColor),
       );
 
-      const defaultConfigArchive =
-        typeof node.configCount === "number"
-          ? (times(
-              node.configCount,
-              (index) => node[`configArchive_${index}`],
-            ).find((archive) => archive.configName === "Default") ??
-            node.configArchive_0)
-          : undefined;
+      let defaultConfigArchive: ConfigArchive | undefined = undefined;
+
+      if (node.configCount) {
+        const names = times(
+          node.configCount,
+          (index) => node[`configArchive_${index}`],
+        );
+
+        defaultConfigArchive = names.find(
+          (archive) => archive.configName === "Default",
+        );
+        defaultConfigArchive ??= node.configArchive_0;
+      }
+
       const customCullMode =
         node.customCullMode ?? defaultConfigArchive?.customCullMode;
 
@@ -204,8 +211,8 @@ export async function extractModel(vfs: AbstractVFS, path: string) {
 
           case "TransformComponent": {
             const localTranslation = component["tc.localTranslation"];
-             // The game resets top-level node translation to [0, 0, 0] on load.
-             // Child nodes must keep their authored local offsets.
+            // The game resets top-level node translation to [0, 0, 0] on load.
+            // Child nodes must keep their authored local offsets.
             node.setTranslation(
               parent instanceof Scene ? [0, 0, 0] : localTranslation,
             );

--- a/packages/scripts/src/core/blitz/extractModel/index.ts
+++ b/packages/scripts/src/core/blitz/extractModel/index.ts
@@ -75,6 +75,19 @@ export async function extractModel(vfs: AbstractVFS, path: string) {
           .setImage(baseColor),
       );
 
+      if (
+        node.enabledPresets?.AlphaTest &&
+        node.properties.alphatestThreshold
+      ) {
+        const view = new DataView(node.properties.alphatestThreshold);
+        const alphaCutoff =
+          view.byteLength < 4
+            ? 0.5
+            : view.getFloat32(view.byteLength - 4, true);
+
+        material.setAlphaMode("MASK").setAlphaCutoff(alphaCutoff);
+      }
+
       if (node.configCount) {
         for (
           let configIndex = 0;
@@ -91,8 +104,10 @@ export async function extractModel(vfs: AbstractVFS, path: string) {
           }
 
           const view = new DataView(archive.properties.alphatestThreshold);
-          const _ = view.getUint8(0); // only god knows what these flags are
-          const alphaCutoff = view.getFloat32(1, true);
+          const alphaCutoff =
+            view.byteLength < 4
+              ? 0.5
+              : view.getFloat32(view.byteLength - 4, true);
 
           material.setAlphaMode("MASK").setAlphaCutoff(alphaCutoff);
         }


### PR DESCRIPTION
- Fixes .sc2 AlphaTest export by reading each material’s `alphatestThreshold` and applying glTF `MASK` alpha with the correct cutoff, so cutout transparency renders correctly.
- Adds support for `customCullMode` export (mapped to glTF [doubleSided](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#double-sided)), so materials configured as no-cull are visible from both sides.

Before:
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/91fd53f3-8a21-4828-ae96-28a8f5a53407" />

After:
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/c77c6a58-2100-42c1-9568-6c1c7d8edd07" />