### PR TITLE
Fix lowercase armor names in static armor view

### DIFF
--- a/packages/website/src/components/Armor/components/ArmorPlateDisplay.tsx
+++ b/packages/website/src/components/Armor/components/ArmorPlateDisplay.tsx
@@ -43,7 +43,7 @@ export function ArmorPlateDisplay() {
             }}
           >
             <Flex direction="column">
-              <Text weight="bold">
+              <Text weight="bold" style={{ textTransform: "capitalize" }}>
                 {layerTypeNames[highlightArmor.type]}{" "}
                 {highlightArmor.thickness.toFixed(0)}
                 <Text size="1" weight="regular">


### PR DESCRIPTION
Armor plate labels ("primary", "spaced", "external") shown in the floating card when clicking armor in the tankopedia 3D sandbox were rendered in lowercase. Added `textTransform: capitalize` to the label in `ArmorPlateDisplay.tsx` so it matches capitalization used elsewhere in the UI.