### PR TITLE
Fix crash on repeated HE shell clicks in Tankopedia armor viewer

### DIFF
--- a/packages/website/src/components/Armor/components/ShotDisplay.tsx
+++ b/packages/website/src/components/Armor/components/ShotDisplay.tsx
@@ -63,10 +63,10 @@ export function ShotDisplay() {
         outlineMaterial,
       ).computeLineDistances();
 
-      splashRadiusWrapper.current.add(outline);
+      splashRadiusWrapper.current?.add(outline);
 
       return () => {
-        splashRadiusWrapper.current.remove(outline);
+        splashRadiusWrapper.current?.remove(outline);
       };
     }
   });
@@ -283,17 +283,23 @@ function Animator({
     const tracerT1 = t % 1;
     const tracerT2 = (t + 0.5) % 1;
 
-    inTracer.current.scale.set(1, 1 - 2 * Math.abs(tracerT1 - 0.5), 1);
-    inTracer.current.position.set(0, (1 - tracerT1) * inLength, 0);
+    if (inTracer.current) {
+      inTracer.current.scale.set(1, 1 - 2 * Math.abs(tracerT1 - 0.5), 1);
+      inTracer.current.position.set(0, (1 - tracerT1) * inLength, 0);
 
-    if (outTracer.current) {
-      outTracer.current.scale.set(1, 1 - 2 * Math.abs(tracerT2 - 0.5), 1);
-      outTracer.current.position.set(0, tracerT2 * outLength, 0);
+      if (outTracer.current) {
+        outTracer.current.scale.set(1, 1 - 2 * Math.abs(tracerT2 - 0.5), 1);
+        outTracer.current.position.set(0, tracerT2 * outLength, 0);
+      }
+
+      invalidate();
     }
 
-    invalidate();
-
-    if (shot.splashRadius !== undefined) {
+    if (
+      shot.splashRadius !== undefined &&
+      splashRadiusWrapper.current &&
+      splashRadiusMaterial.current
+    ) {
       if (animationStartTime === null) animationStartTime = t;
 
       const scale =

--- a/packages/website/src/components/Armor/components/ShotDisplay.tsx
+++ b/packages/website/src/components/Armor/components/ShotDisplay.tsx
@@ -42,10 +42,10 @@ const TRACER_THIN = TRACER_THICK / 2;
 
 export function ShotDisplay() {
   const shot = Tankopedia.use((state) => state.shot);
-  const inTracer = useRef<Mesh>(null!);
-  const outTracer = useRef<Mesh>(null!);
-  const splashRadiusWrapper = useRef<Group>(null!);
-  const splashRadiusMaterial = useRef<MeshBasicMaterial>(null!);
+  const inTracer = useRef<Mesh>(null);
+  const outTracer = useRef<Mesh>(null);
+  const splashRadiusWrapper = useRef<Group>(null);
+  const splashRadiusMaterial = useRef<MeshBasicMaterial>(null);
   const { locale } = useLocale();
 
   useEffect(() => {
@@ -255,11 +255,11 @@ export function ShotDisplay() {
 }
 
 interface AnimatorProps {
-  inTracer: RefObject<Mesh>;
-  outTracer: RefObject<Mesh>;
+  inTracer: RefObject<Mesh | null>;
+  outTracer: RefObject<Mesh | null>;
 
-  splashRadiusWrapper: RefObject<Group>;
-  splashRadiusMaterial: RefObject<MeshBasicMaterial>;
+  splashRadiusWrapper: RefObject<Group | null>;
+  splashRadiusMaterial: RefObject<MeshBasicMaterial | null>;
 
   inLength: number;
   outLength: number;


### PR DESCRIPTION
## Overview
Repeatedly clicking the tank model with **HE** shells selected on the Tankopedia armor page could crash the page. AP/HEAT shots were unaffected.

## Root cause
In `ShotDisplay.tsx`, the `Animator` component's `useFrame` callback read `splashRadiusWrapper.current` / `splashRadiusMaterial.current` without null checks. These refs are only attached while the HE-specific splash-radius `<group>` is mounted, and R3F's `useFrame` runs on an independent rAF loop decoupled from React's commit/ref-attach timing. On rapid HE clicks there's a window where the previous shot's splash group has unmounted (ref → `null`) before the new one attaches, causing an uncaught `TypeError` inside the render loop. With no error boundary around the `Canvas`, this took down the whole page.

This was a regression from commit `19f22993` ("optimize shot display animator"), which dropped ref-null guards that existed in the prior implementation.

## Fix
Restored the original guard pattern:
- `splashRadiusWrapper.current` accesses in the outline-effect cleanup now use optional chaining (`?.`).
- The `Animator` `useFrame` callback now only updates tracer transforms `if (inTracer.current)`, and only updates the splash-radius scale/opacity when `splashRadiusWrapper.current && splashRadiusMaterial.current` are both non-null.

## Testing
- Repeated HE clicks on the tank model no longer crash the page.
- Typecheck passes for the changed file.