### PR TITLE
Fix dead early-return in ricochet bounce logic

### DIFF
--- a/packages/website/src/components/Armor/components/SpacedArmorSceneComponent/index.tsx
+++ b/packages/website/src/components/Armor/components/SpacedArmorSceneComponent/index.tsx
@@ -161,9 +161,10 @@ export function SpacedArmorSceneComponent({
 
       if (
         !allowRicochet &&
-        noDuplicateIntersections.every((intersection) => {
-          intersection.object.userData.type !== ArmorType.Primary;
-        })
+        noDuplicateIntersections.every(
+          (intersection) =>
+            intersection.object.userData.type !== ArmorType.Primary,
+        )
       ) {
         return null;
       }


### PR DESCRIPTION
## Summary
After a shot ricochets off primary armor, `shoot()` recursively casts a reflected ray to simulate the bounced shell. The early-return guard meant to bail out when that bounced ray hits no further primary armor was dead code — the `.every()` callback used a block body with no `return`, so it always evaluated to `undefined`/falsy and the guard never fired.

As a result, a ricochet whose bounced trajectory only clipped an external module (tracks, gun barrel) would fall through into the normal penetration pipeline and could be scored as a successful penetration, even though the shot should have been a dead ricochet with no further effect.

## Fix
- Add the missing `return` in the `.every()` predicate so the guard actually short-circuits as intended.