### PR TITLE
Fix Safari crash on mixer texture disposal

### DIFF
--- a/packages/website/src/hooks/useDispose.ts
+++ b/packages/website/src/hooks/useDispose.ts
@@ -36,7 +36,9 @@ export function useDispose(gltf: GLTF & ObjectMap, path: string) {
             for (const map of maps) {
               if (!map) continue;
 
-              map.source.data.close();
+              if (typeof map.source.data.close === "function") {
+                map.source.data.close();
+              }
               map.dispose();
             }
 

--- a/packages/website/src/hooks/useDispose.ts
+++ b/packages/website/src/hooks/useDispose.ts
@@ -36,9 +36,10 @@ export function useDispose(gltf: GLTF & ObjectMap, path: string) {
             for (const map of maps) {
               if (!map) continue;
 
-              if (typeof map.source.data.close === "function") {
+              if (map.source.data instanceof ImageBitmap) {
                 map.source.data.close();
               }
+
               map.dispose();
             }
 


### PR DESCRIPTION
`useDispose.ts` unconditionally called `map.source.data.close()` when disposing a model's textures, assuming the texture source is always an `ImageBitmap`. Chrome decodes GLTF textures via `createImageBitmap`, so `.close()` exists there, but Safari lacks support for the `createImageBitmap` options three.js needs and falls back to `HTMLImageElement`, which has no `.close()` method. This threw a `TypeError` every time the mixer swapped models (Randomize, manual part change) on Safari, crashing the page since there's no error boundary — the first load never crashed because disposal only runs on teardown of a previous model.

Fix: only call `.close()` when it exists on the texture source before disposing.
