### PR TITLE
Fix harsh/patchy lighting and shadows in mixer & tankopedia model viewer

### DIFF
--- a/packages/website/src/components/Tankopedia/HeroSection/components/TankSandbox/components/Lighting.tsx
+++ b/packages/website/src/components/Tankopedia/HeroSection/components/TankSandbox/components/Lighting.tsx
@@ -8,17 +8,17 @@ import { Tankopedia } from "../../../../../../stores/tankopedia";
 import { TankopediaPersistent } from "../../../../../../stores/tankopediaPersistent";
 import { HelpingSpotLight } from "../../../../../HelpingSpotLight";
 
-const ANGLE = degToRad(10);
+const ANGLE = degToRad(32);
 const REVEAL_ANIMATION_TIME = 3;
 const TRANSITION_ANIMATION_TIME = 0.5;
 
 const LIGHTS_COUNT = 4;
 const THETA_OFFSET = degToRad(180 - 45);
-const LIGHT_DISTANCE = 20;
+const LIGHT_DISTANCE = 14;
 const LIGHT_HEIGHT_0 = 4;
 const LIGHT_HEIGHT_1 = 6;
-const INTENSITY_0 = 6;
-const INTENSITY_1 = 3;
+const INTENSITY_0 = 4;
+const INTENSITY_1 = 2;
 const HEMISPHERE_INTENSITY = 2;
 
 export const transitionEvent = new Quicklime<number>(0);
@@ -35,8 +35,6 @@ export function Lighting() {
   const isRevealing = useRef(true);
 
   const [animate, setAnimate] = useState(true);
-
-  console.log(animate);
 
   useEffect(() => {
     Tankopedia.mutate((draft) => {
@@ -88,7 +86,9 @@ export function Lighting() {
               position={position}
               intensity={intensity}
               penumbra={1}
-              castShadow={highGraphics}
+              castShadow={highGraphics && index === 0}
+              shadow-mapSize={[2048, 2048]}
+              shadow-bias={-0.0005}
               decay={0}
               color="#ffffff"
               angle={0}

--- a/packages/website/src/components/Tankopedia/HeroSection/components/TankSandbox/index.tsx
+++ b/packages/website/src/components/Tankopedia/HeroSection/components/TankSandbox/index.tsx
@@ -156,7 +156,7 @@ export const TankSandbox = forwardRef<HTMLCanvasElement, TankSandboxProps>(
           localClippingEnabled: true,
           preserveDrawingBuffer: true,
         }}
-        shadows="basic"
+        shadows="soft"
         onPointerDown={handlePointerDown}
         onPointerMissed={() => {
           Tankopedia.mutate((draft) => {


### PR DESCRIPTION
The rig lighting shared by the Mixer and Tankopedia tank views (`Lighting.tsx`)
had been retuned in a recent "optimize scene lighting" pass to very narrow
spotlight cones (10° half-angle) at a longer distance (20 units), with only 4
lights. That combination left large unlit gaps between beams and pooled hot,
hard-edged spots on models — hulls crushed while turret roofs
blew out.

- Widened spotlight cones back out (10° → 32° half-angle) and pulled them
  closer (distance 20 → 14), with intensity re-balanced (6/3 → 4/2) so
  coverage is even instead of patchy.
- Removed a leftover debug `console.log(animate)` from that same refactor.
- Fixed blocky/pixelated shadow edges introduced by the wider cones (same
  fixed shadow-map resolution now stretched over a much bigger area, times 4
  overlapping lights): only the single brightest/closest light now casts a
  shadow, at 2048×2048 with a small bias, and the tankopedia canvas moved
  from `shadows="basic"` (unfiltered, hard pixels) to `shadows="soft"`
  (PCF-filtered) to match the mixer.