### PR TITLE
Feature: Add Spall Liner toggle to Tankopedia model viewer

### DIFF
--- a/packages/i18n/strings/en.json
+++ b/packages/i18n/strings/en.json
@@ -1065,6 +1065,10 @@
               "label": "Edit",
               "reset": "Reset"
             }
+          },
+
+          "spall_liner": {
+            "swap_prompt": "Spall Liner will replace one of your active provisions. Choose which one to remove:"
           }
         },
 

--- a/packages/website/src/components/Armor/components/SpacedArmorSceneComponent/index.tsx
+++ b/packages/website/src/components/Armor/components/SpacedArmorSceneComponent/index.tsx
@@ -18,6 +18,10 @@ import {
 import { degToRad } from "three/src/math/MathUtils.js";
 import { hasEquipment } from "../../../../core/blitzkit/hasEquipment";
 import { jsxTree } from "../../../../core/blitzkit/jsxTree";
+import {
+  SPALL_LINER_HE_DAMAGE_DELTA,
+  SPALL_LINER_PROVISION_ID,
+} from "../../../../core/blitzkit/spallLiner";
 import { defaultEqualizer } from "../../../../core/blitzkit/tankToDuelMember";
 import { discardClippingPlane } from "../../../../core/three/discardClippingPlane";
 import { Duel } from "../../../../stores/duel";
@@ -383,6 +387,13 @@ export function SpacedArmorSceneComponent({
       }
 
       shot.damage *= antagonistEqualizer.damage;
+
+      const hasSpallLiner = Duel.state.protagonist.provisions.includes(
+        SPALL_LINER_PROVISION_ID,
+      );
+      if (hasSpallLiner && shell.type === ShellType.SHELL_TYPE_HE) {
+        shot.damage *= 1 + SPALL_LINER_HE_DAMAGE_DELTA;
+      }
 
       return shot;
     },

--- a/packages/website/src/components/Tankopedia/HeroSection/components/Options/components/SpallLinerSwitcher.tsx
+++ b/packages/website/src/components/Tankopedia/HeroSection/components/Options/components/SpallLinerSwitcher.tsx
@@ -1,0 +1,103 @@
+import { asset, availableProvisions } from "@blitzkit/core";
+import { Flex, IconButton, Popover, Text } from "@radix-ui/themes";
+import { awaitableProvisionDefinitions } from "../../../../../../core/awaitables/provisionDefinitions";
+import { SPALL_LINER_PROVISION_ID } from "../../../../../../core/blitzkit/spallLiner";
+import { useLocale } from "../../../../../../hooks/useLocale";
+import { Duel } from "../../../../../../stores/duel";
+import { Tankopedia } from "../../../../../../stores/tankopedia";
+import { ProvisionButton } from "../../../../../ModuleButtons/ProvisionButton";
+
+const provisionDefinitions = await awaitableProvisionDefinitions;
+
+export function SpallLinerSwitcher() {
+  const { tank, gun, provisions } = Duel.use((state) => state.protagonist);
+  const { strings, unwrap } = useLocale();
+  const isSpallLinerActive = provisions.includes(SPALL_LINER_PROVISION_ID);
+  const hasSlotAvailable = provisions.length < tank.max_provisions;
+
+  const canEquipSpallLiner = availableProvisions(
+    tank,
+    gun,
+    provisionDefinitions,
+  ).some((provision) => provision.id === SPALL_LINER_PROVISION_ID);
+
+  if (!canEquipSpallLiner) return null;
+
+  function equip(replacing?: number) {
+    Duel.mutate((draft) => {
+      if (replacing !== undefined) {
+        const provisions = draft.protagonist.provisions;
+        provisions[provisions.indexOf(replacing)] = SPALL_LINER_PROVISION_ID;
+      } else {
+        draft.protagonist.provisions.push(SPALL_LINER_PROVISION_ID);
+      }
+    });
+    Tankopedia.mutate((draft) => {
+      draft.shot = undefined;
+    });
+  }
+
+  function unequip() {
+    Duel.mutate((draft) => {
+      draft.protagonist.provisions = draft.protagonist.provisions.filter(
+        (id) => id !== SPALL_LINER_PROVISION_ID,
+      );
+    });
+    Tankopedia.mutate((draft) => {
+      draft.shot = undefined;
+    });
+  }
+
+  const button = (
+    <IconButton
+      color={isSpallLinerActive ? undefined : "gray"}
+      variant="soft"
+      size={{ initial: "2", sm: "3" }}
+      radius="none"
+      onClick={() => {
+        if (isSpallLinerActive) {
+          unequip();
+        } else if (hasSlotAvailable) {
+          equip();
+        }
+      }}
+    >
+      <img
+        alt={unwrap(provisionDefinitions.provisions[SPALL_LINER_PROVISION_ID].name!)}
+        src={asset(`icons/provisions/${SPALL_LINER_PROVISION_ID}.webp`)}
+        style={{
+          width: "50%",
+          height: "50%",
+        }}
+      />
+    </IconButton>
+  );
+
+  if (isSpallLinerActive || hasSlotAvailable) return button;
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger>{button}</Popover.Trigger>
+
+      <Popover.Content>
+        <Flex direction="column" gap="2" maxWidth="240px">
+          <Text size="2" color="gray">
+            {strings.website.tools.tankopedia.sandbox.spall_liner.swap_prompt}
+          </Text>
+
+          <Flex gap="2" wrap="wrap">
+            {provisions.map((id) => (
+              <Popover.Close key={id}>
+                <ProvisionButton
+                  provision={id}
+                  selected={false}
+                  onClick={() => equip(id)}
+                />
+              </Popover.Close>
+            ))}
+          </Flex>
+        </Flex>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/packages/website/src/components/Tankopedia/HeroSection/components/Options/index.tsx
+++ b/packages/website/src/components/Tankopedia/HeroSection/components/Options/index.tsx
@@ -46,6 +46,7 @@ import { TankSearch } from "../../../../TankSearch";
 import { CustomShellButton } from "./components/CustomShellButton";
 import { DynamicArmorSwitcher } from "./components/DynamicArmorSwitcher";
 import { QuickInputs } from "./components/QuickInputs";
+import { SpallLinerSwitcher } from "./components/SpallLinerSwitcher";
 import { Thicknesses } from "./components/Thicknesses";
 
 type OptionsProps = MaybeSkeletonComponentProps & {
@@ -278,6 +279,8 @@ export function Options({ thicknessRange, canvas, skeleton }: OptionsProps) {
               }}
             />
           </IconButton>
+
+          <SpallLinerSwitcher />
         </Flex>
 
         {!skeleton && (

--- a/packages/website/src/core/blitzkit/spallLiner.ts
+++ b/packages/website/src/core/blitzkit/spallLiner.ts
@@ -1,0 +1,8 @@
+export const SPALL_LINER_PROVISION_ID = 101;
+
+/**
+ * Matches the in-game reduction Spall Liner grants against HE splash
+ * damage. Shared between the characteristics panel and the Dynamic
+ * Armor 3D viewer's damage readout so the figure isn't duplicated.
+ */
+export const SPALL_LINER_HE_DAMAGE_DELTA = -0.2;

--- a/packages/website/src/core/blitzkit/tankCharacteristics.ts
+++ b/packages/website/src/core/blitzkit/tankCharacteristics.ts
@@ -22,6 +22,7 @@ import {
 } from "@blitzkit/core";
 import { coefficient } from "@blitzkit/core/src/blitzkit/coefficient";
 import type { EquipmentMatrix } from "../../stores/duel";
+import { SPALL_LINER_HE_DAMAGE_DELTA } from "./spallLiner";
 import { defaultEqualizer } from "./tankToDuelMember";
 
 export type TankCharacteristics = ReturnType<typeof tankCharacteristics>;
@@ -170,7 +171,10 @@ export function tankCharacteristics(
     coefficient(
       [applyReactiveArmor && shell.type !== ShellType.SHELL_TYPE_HE, -0.27],
       [applyDynamicArmor, -0.1],
-      [applySpallLiner && shell.type === ShellType.SHELL_TYPE_HE, -0.2],
+      [
+        applySpallLiner && shell.type === ShellType.SHELL_TYPE_HE,
+        SPALL_LINER_HE_DAMAGE_DELTA,
+      ],
     );
   const assaultDamageCoefficient =
     gun.assault_ranges && gun.assault_ranges.types.includes(shell.type)


### PR DESCRIPTION
## Summary
- Add a Spall Liner toggle button to the Tankopedia model viewer, placed alongside the existing Calibrated Shells / Enhanced Armor buttons. It's only shown for tanks that can actually equip Spall Liner.
- The toggle reads/writes the same `Duel.protagonist.provisions` array as the Provisions tab, so both stay in sync automatically.
- If fewer than 3 provisions are active, clicking equips Spall Liner immediately. If all 3 slots are full, a popover appears letting you pick which active provision to swap out in one step.
- When Spall Liner is equipped, the Dynamic Armor 3D viewer's click-damage tooltip now applies the same 20% HE damage reduction Spall Liner grants in-game.
- Refactored the existing hardcoded `-0.2` HE damage coefficient in `tankCharacteristics.ts` into a shared constant so the Compare tool and the 3D viewer use a single source of truth.
- Spall Liner's name/icon reuse the already-localized in-game provision name (via `unwrap()`), and the new popover copy is added to `en.json` following the existing i18n conventions.

## Scope
This only affects the single-tank Tankopedia page. The Firepower stats table (which shows the viewed tank's own outgoing gun damage) was intentionally left untouched, since applying a defensive damage reduction there would be semantically backwards — the only place a "damage taken by this tank" number already exists is the Dynamic Armor viewer's click tooltip, so that's where the reduction was wired in.
