### PR TITLE
Feature: Add peekaboo DPM stat to Tankopedia firepower

### DIFF
--- a/packages/i18n/strings/en.json
+++ b/packages/i18n/strings/en.json
@@ -1169,6 +1169,8 @@
             "shellRicochet": "Ricochet",
             "dpm": "DPM",
             "dpmEffective": "Effective at 60s",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Shells",
             "mostOptimalShellIndex": "Most optimal shell",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/es.json
+++ b/packages/i18n/strings/es.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "Rebote",
             "dpm": "DPM",
             "dpmEffective": "Effective at 60s",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Proyectiles",
             "mostOptimalShellIndex": "Proyectil más óptimo",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/fr.json
+++ b/packages/i18n/strings/fr.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "Ricochet",
             "dpm": "DPM",
             "dpmEffective": "Effective at 60s",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Shells",
             "mostOptimalShellIndex": "Most optimal shell",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/ja.json
+++ b/packages/i18n/strings/ja.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "跳弾角度",
             "dpm": "DPM",
             "dpmEffective": "60秒での有効値",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "砲弾",
             "mostOptimalShellIndex": "最適な弾数",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/pl.json
+++ b/packages/i18n/strings/pl.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "Ricochet",
             "dpm": "DPM",
             "dpmEffective": "Effective at 60s",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Shells",
             "mostOptimalShellIndex": "Most optimal shell",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/pt.json
+++ b/packages/i18n/strings/pt.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "Ricochete",
             "dpm": "DPM",
             "dpmEffective": "Efetivo aos 60s",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Projéteis",
             "mostOptimalShellIndex": "Projétil mais ideal",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/ru.json
+++ b/packages/i18n/strings/ru.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "Рикошет",
             "dpm": "ДПМ",
             "dpmEffective": "Эффективность за 60с",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Снарядов в барабане",
             "mostOptimalShellIndex": "Самый эффективный снаряд",
             "shellReloads": "Перезарядка",

--- a/packages/i18n/strings/uk.json
+++ b/packages/i18n/strings/uk.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "Рикошет",
             "dpm": "DPM",
             "dpmEffective": "Effective at 60s",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "Снаряди",
             "mostOptimalShellIndex": "Most optimal shell",
             "shellReloads": "Reloads",

--- a/packages/i18n/strings/zh.json
+++ b/packages/i18n/strings/zh.json
@@ -1040,6 +1040,8 @@
             "shellRicochet": "跳弹",
             "dpm": "每分钟伤害",
             "dpmEffective": "60秒内生效",
+            "peekabooDpm": "Peekaboo DPM",
+            "peekabooDpmInfo": "Damage per minute assuming you only fire after resetting camouflage (or the reload finishes, if it's slower) \u2014 at least 10 seconds between shots.",
             "shells": "炮弹 ",
             "mostOptimalShellIndex": "最优炮弹",
             "shellReloads": "装填时间",

--- a/packages/website/src/components/Tankopedia/CharacteristicsSection/components/Characteristics/components/Firepower.tsx
+++ b/packages/website/src/components/Tankopedia/CharacteristicsSection/components/Characteristics/components/Firepower.tsx
@@ -1,6 +1,14 @@
 import { asset, isExplosive } from "@blitzkit/core";
 import { literals } from "@blitzkit/i18n";
-import { Flex, Heading, IconButton, Tooltip } from "@radix-ui/themes";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import {
+  Flex,
+  Heading,
+  IconButton,
+  Popover,
+  Text,
+  Tooltip,
+} from "@radix-ui/themes";
 import { useLocale } from "../../../../../../hooks/useLocale";
 import { useTankModelDefinition } from "../../../../../../hooks/useTankModelDefinition";
 import { Duel } from "../../../../../../stores/duel";
@@ -77,6 +85,40 @@ export function Firepower({
         {strings.common.gun_types[gun.gun_type!.$case]}
       </Info>
       <InfoWithDelta stats={stats} decimals={0} value="dpm" />
+      {gun.gun_type!.$case === "regular" && (
+        <InfoWithDelta
+          stats={stats}
+          indent
+          decimals={0}
+          noRanking
+          name={
+            <Flex align="center" gap="1" display="inline-flex">
+              {
+                strings.website.tools.tankopedia.characteristics.values
+                  .peekabooDpm
+              }
+
+              <Popover.Root>
+                <Popover.Trigger>
+                  <IconButton variant="ghost" size="1">
+                    <InfoCircledIcon />
+                  </IconButton>
+                </Popover.Trigger>
+
+                <Popover.Content style={{ maxWidth: 280 }}>
+                  <Text size="2">
+                    {
+                      strings.website.tools.tankopedia.characteristics.values
+                        .peekabooDpmInfo
+                    }
+                  </Text>
+                </Popover.Content>
+              </Popover.Root>
+            </Flex>
+          }
+          value={(tank) => tank.peekabooDpm}
+        />
+      )}
       <InfoWithDelta stats={stats} decimals={0} value="damage" />
       {gun.gun_type!.$case !== "regular" && (
         <InfoWithDelta stats={stats} indent decimals={0} value="clipDamage" />

--- a/packages/website/src/core/blitzkit/tankCharacteristics.ts
+++ b/packages/website/src/core/blitzkit/tankCharacteristics.ts
@@ -424,6 +424,10 @@ export function tankCharacteristics(
       : (gun.gun_type!.$case === "regular"
           ? gun.gun_type!.value.reload
           : gun.gun_type!.value.clip_reload) * reloadCoefficient;
+  const peekabooDpm =
+    gun.gun_type!.$case === "regular"
+      ? Math.round(damage * (60 / Math.max(shellReload!, 10)))
+      : undefined;
   const caliber = shell.caliber;
   const penetration = shell.penetration!.near * penetrationCoefficient;
   const clipDamage =
@@ -551,6 +555,7 @@ export function tankCharacteristics(
     shellRicochet,
     dpm,
     dpmEffective,
+    peekabooDpm,
     shells,
     mostOptimalShellIndex,
     shellReloads,


### PR DESCRIPTION
Adds a **Peekaboo DPM** entry nested under DPM for single-shot guns, estimating damage per minute when only firing after resetting camouflage (or waiting out the reload, whichever is slower), assuming at least 10 seconds between shots.

- Shots per minute are capped at `60/10` for reloads faster than 10s, and fall back to `60/reload` otherwise
- The result is multiplied by the currently selected shell's damage and rounded
- An (i) icon next to the label opens a popover explaining the calculation
- The row is hidden for auto-loader/auto-reloader guns
- No percentile ranking bar is shown, since no dataset exists yet for this new stat