### PR TITLE
Fix: gun depression visualizer ignoring turret mount tilt

### DIFF
--- a/packages/website/src/components/Tankopedia/CharacteristicsSection/components/Characteristics/components/GunFlexibilityVisualizer/components/CanvasContent.tsx
+++ b/packages/website/src/components/Tankopedia/CharacteristicsSection/components/Characteristics/components/GunFlexibilityVisualizer/components/CanvasContent.tsx
@@ -1,6 +1,7 @@
 import type { QuicklimeEvent } from "quicklime";
 import { useEffect, useRef } from "react";
 import type { Group } from "three";
+import { degToRad } from "three/src/math/MathUtils.js";
 import { awaitableModelDefinitions } from "../../../../../../../../core/awaitables/modelDefinitions";
 import {
   modelTransformEvent,
@@ -20,6 +21,13 @@ export function CanvasContent() {
 
   const tankModel = modelDefinitions.models[tank.id];
   const turretModel = tankModel.turrets[turret.id];
+
+  // baked-in turret mount tilt (e.g. Minotauro sits pitched 3deg forward);
+  // applied as a static base rotation so the live gun pitch composes on top
+  // of it, mirroring useTankTransform.ts's turretContainer/gunContainer nesting
+  const initialTurretPitch = -degToRad(
+    tankModel.initial_turret_rotation?.pitch ?? 0,
+  );
 
   useEffect(() => {
     function handleModelTransformEvent(
@@ -45,10 +53,12 @@ export function CanvasContent() {
         </group>
       </group>
 
-      <ModelChunk only="turret" />
+      <group rotation={[initialTurretPitch, 0, 0]}>
+        <ModelChunk only="turret" />
 
-      <group ref={gunWrapper}>
-        <ModelChunk only="gun" />
+        <group ref={gunWrapper}>
+          <ModelChunk only="gun" />
+        </group>
       </group>
     </>
   );

--- a/packages/website/src/components/Tankopedia/CharacteristicsSection/components/Characteristics/components/GunFlexibilityVisualizer/index.tsx
+++ b/packages/website/src/components/Tankopedia/CharacteristicsSection/components/Characteristics/components/GunFlexibilityVisualizer/index.tsx
@@ -48,13 +48,22 @@ export function GunFlexibilityVisualizer({
   const turretModel = tankModel.turrets[turret.id];
   const gunModel = turretModel.guns[gun.id];
 
+  // turret's own baked-in mount tilt (e.g. Minotauro's turret sits pitched
+  // 3deg forward on the hull); must be folded into displayed pitch values
+  // the same way tankCharacteristics.ts and QuickInputs do
+  const initialTurretPitch = degToRad(
+    tankModel.initial_turret_rotation?.pitch ?? 0,
+  );
+
   const [yaw, setYaw] = useState(0);
   const [pitch, setPitch] = useState(0);
   const [minPitch, setMinPitch] = useState(
-    -degToRad(gunModel.pitch!.front?.max ?? gunModel.pitch!.max),
+    -degToRad(gunModel.pitch!.front?.max ?? gunModel.pitch!.max) -
+      initialTurretPitch,
   );
   const [maxPitch, setMaxPitch] = useState(
-    -degToRad(gunModel.pitch!.front?.min ?? gunModel.pitch!.min),
+    -degToRad(gunModel.pitch!.front?.min ?? gunModel.pitch!.min) -
+      initialTurretPitch,
   );
 
   const container = useRef<HTMLDivElement>(null);
@@ -256,8 +265,8 @@ export function GunFlexibilityVisualizer({
 
           setPitch(pitch);
           setYaw(yaw);
-          setMinPitch(min[0]);
-          setMaxPitch(max[0]);
+          setMinPitch(min[0] - initialTurretPitch);
+          setMaxPitch(max[0] - initialTurretPitch);
 
           modelTransformEvent.dispatch({ pitch, yaw });
         }}
@@ -376,7 +385,7 @@ export function GunFlexibilityVisualizer({
         <VisualizerCornerStat
           label={strings.website.tools.tankopedia.visualizers.flexibility.pitch}
           value={literals(strings.common.units.deg, {
-            value: radToDeg(pitch).toFixed(0),
+            value: radToDeg(pitch - initialTurretPitch).toFixed(0),
           })}
           side="top-left"
         />


### PR DESCRIPTION
The gun flexibility visualizer at the bottom of the Tankopedia Firepower section computed depression/elevation purely from the raw gun `pitch.min`/`pitch.max` values, ignoring `initial_turret_rotation.pitch` — the tank's baked-in turret mount tilt. Every other place that reports gun depression/elevation (the Firepower stats block, quick pitch/yaw inputs, tank search sorting, tank cards, and the 3D sandbox transform) already accounts for this offset; the visualizer was the outlier.

On tanks with a level turret mount this offset is zero, so it was invisible almost everywhere. Minotauro's turret sits pitched 3° forward (`initial_turret_rotation.pitch = 3`), which made the visualizer's "min"/"max"/"pitch" stats and wedge shape disagree with the Firepower stats directly above it (e.g. showing 7°/-18° instead of the correct 10°/15°).

**Changes:**
- `GunFlexibilityVisualizer/index.tsx`: fold the turret's initial pitch offset into `minPitch`, `maxPitch`, and the displayed `pitch` stat, both on initial load and while dragging.
- `GunFlexibilityVisualizer/components/CanvasContent.tsx`: nest the gun mesh inside a turret group carrying the same static tilt as its base rotation, so the mini 3D preview's live drag-pitch composes on top of it, mirroring the pattern already used in the main Hero section sandbox (`useTankTransform.ts`).